### PR TITLE
feat: Add anchor links to headers

### DIFF
--- a/.github/scripts/site-templates/index.html.j2
+++ b/.github/scripts/site-templates/index.html.j2
@@ -8,7 +8,7 @@
 
     <h1>Test Results</h1>
     {% for emulator_version, platforms in emulator_grouped_results | version_sort -%}
-        <h2>{{ emulator_version }}</h2>
+        <h2 id="{{ emulator_version }}">{{ emulator_version }}</h2>
         <ul>
         {%- for platform, renderers in platforms | dictsort %}
             <li>

--- a/.github/scripts/site-templates/script.js.j2
+++ b/.github/scripts/site-templates/script.js.j2
@@ -61,15 +61,11 @@ function enableViewLinks(document) {
     });
 }
 
-function enableAnchorCopying(document) {
+function enableAnchorLinks(document) {
     function addClickHandler(element) {
         if (element.id) {
             element.addEventListener('click', () => {
-                const currentURL = window.location.href.split('#');
-                const anchor = element.id;
-                const urlWithAnchor = `${currentURL}#${anchor}`;
-
-                navigator.clipboard.writeText(urlWithAnchor)
+                window.location.hash = element.id;
             });
         }
     }
@@ -83,5 +79,5 @@ function enableAnchorCopying(document) {
 document.addEventListener('DOMContentLoaded', () => {
     enableViewLinks(document);
     enableImagePairs(document);
-    enableAnchorCopying(document);
+    enableAnchorLinks(document);
 });


### PR DESCRIPTION
This change adds anchor links to the headers on the generated website. When a user clicks on a header, the URL is updated with an anchor corresponding to that header's ID. This allows users to directly navigate to specific sections of the page.

The implementation involves two main changes:
1.  The `index.html.j2` template is modified to add an `id` attribute to the `h2` tags, using the `emulator_version` as the ID.
2.  The `script.js.j2` file is updated to add a click event listener to all headers with an ID. This event listener updates `window.location.hash` to the header's ID when clicked, which updates the URL with the anchor.